### PR TITLE
Fix open module import

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,8 @@ async function acquireToken(pca, scopes) {
 
   const result = await pca.acquireTokenInteractive({
     scopes,
-    openBrowser: (url) => {
-      const open = require('open');
+    openBrowser: async (url) => {
+      const { default: open } = await import('open');
       return open(url);
     }
   });


### PR DESCRIPTION
## Summary
- use dynamic `import()` for the `open` module so Node can load the ESM package

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68875fb7f5c4832bbc7f8334bd893eb4